### PR TITLE
docs(cn): add missing query_video_generation in tool list

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -103,6 +103,7 @@
 |`voice_clone`|根据指定音频文件克隆音色|
 |`generate_video`|根据指定 prompt 生成视频|
 |`text_to_image`|根据指定 prompt 生成图片|
+|`query_video_generation`|查询视频生成任务结果|
 |`music_generation`|根据指定 prompt 和歌词生成音乐|
 |`voice_design`|根据指定 prompt 生成音色和试听文本|
 


### PR DESCRIPTION
## Summary
- add missing `query_video_generation` row to the Chinese README tool table

## Why
The English README lists this tool, but the Chinese table currently misses it, which can confuse users following async video generation workflows.
