### PR TITLE
docs: add OpenCode MCP config troubleshooting FAQ

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -141,6 +141,15 @@ which uvx
 或者放到本地客户端的规则中 (以 Cursor 为例):
 <img src="https://public-cdn-video-data-algeng.oss-cn-wulanchabu.aliyuncs.com/cursor_video_rule.png?x-oss-process=image/resize,p_50/format,webp" style="display: inline-block; vertical-align: middle;"/>
 
+### 4. OpenCode 添加 MiniMax MCP 后启动失败（配置校验错误）
+如果 OpenCode 提示配置校验失败（例如 `mcp.MiniMax` 下字段不被识别），请检查：
+
+- 你的 OpenCode 版本对应的 MCP 配置 schema 是否与当前写法一致；
+- 是否按 OpenCode 官方文档将字段映射为该版本支持的结构（本 README 主要提供 Claude/Cursor 示例）；
+- 模型 provider 配置与 MCP server 配置是否分别放在各自的配置段中。
+
+建议先以 OpenCode 官方文档为准，再把 `MINIMAX_API_KEY`、`MINIMAX_API_HOST` 等环境变量填入其支持的 MCP 结构。
+
 
 ## 使用示例
 

--- a/README.md
+++ b/README.md
@@ -140,6 +140,15 @@ Define completion rules before starting:
 Alternatively, these rules can be configured in your IDE settings (e.g., Cursor):
 <img src="https://public-cdn-video-data-algeng.oss-cn-wulanchabu.aliyuncs.com/cursor_video_rule.png?x-oss-process=image/resize,p_50/format,webp" style="display: inline-block; vertical-align: middle;"/>
 
+### 4. OpenCode fails to start after adding MiniMax MCP config
+If OpenCode reports config validation errors (for example, unrecognized keys in `mcp.MiniMax`), verify:
+
+- OpenCode's MCP schema/version matches the config format you are using.
+- You translated fields according to OpenCode docs (this README primarily provides Claude/Cursor examples).
+- Model provider settings and MCP server settings are configured in their respective sections.
+
+For OpenCode-specific keys and structure, follow the latest OpenCode documentation first, then map MiniMax env vars (`MINIMAX_API_KEY`, `MINIMAX_API_HOST`) into that schema.
+
 
 ## Example usage
 


### PR DESCRIPTION
## Summary
- add an OpenCode troubleshooting FAQ entry in both English and Chinese README
- explain common config-validation causes and remind users to follow OpenCode's MCP schema for their specific version

## Why
Users reported startup failures caused by MCP config schema mismatch in OpenCode environments.

Refs #46
