### PR TITLE
docs: clarify OAuth discovery expectations for custom MCP endpoints

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -141,6 +141,21 @@ which uvx
 或者放到本地客户端的规则中 (以 Cursor 为例):
 <img src="https://public-cdn-video-data-algeng.oss-cn-wulanchabu.aliyuncs.com/cursor_video_rule.png?x-oss-process=image/resize,p_50/format,webp" style="display: inline-block; vertical-align: middle;"/>
 
+### 4. OpenCode 添加 MiniMax MCP 后启动失败（配置校验错误）
+如果 OpenCode 提示配置校验失败（例如 `mcp.MiniMax` 下字段不被识别），请检查：
+
+- 你的 OpenCode 版本对应的 MCP 配置 schema 是否与当前写法一致；
+- 是否按 OpenCode 官方文档将字段映射为该版本支持的结构（本 README 主要提供 Claude/Cursor 示例）；
+- 模型 provider 配置与 MCP server 配置是否分别放在各自的配置段中。
+
+建议先以 OpenCode 官方文档为准，再把 `MINIMAX_API_KEY`、`MINIMAX_API_HOST` 等环境变量填入其支持的 MCP 结构。
+
+### 5. MiniMax MCP 是否支持标准 MCP OAuth discovery？
+本仓库（`MiniMax-MCP`）主要是 MCP Server 实现，常见接入方式是通过 API Key 环境变量配置。  
+“添加第三方 MCP 服务时的 OAuth 发现/授权流程”是否可用，取决于具体 MCP 客户端产品（如网页端/IDE 集成）的实现能力，而不只取决于本仓库。
+
+如果你在接入自定义 MCP URL 时遇到 OAuth URL 获取失败，请优先核对对应客户端最新文档中要求的 discovery 地址与 OAuth 配置方式。
+
 
 ## 使用示例
 

--- a/README.md
+++ b/README.md
@@ -140,6 +140,21 @@ Define completion rules before starting:
 Alternatively, these rules can be configured in your IDE settings (e.g., Cursor):
 <img src="https://public-cdn-video-data-algeng.oss-cn-wulanchabu.aliyuncs.com/cursor_video_rule.png?x-oss-process=image/resize,p_50/format,webp" style="display: inline-block; vertical-align: middle;"/>
 
+### 4. OpenCode fails to start after adding MiniMax MCP config
+If OpenCode reports config validation errors (for example, unrecognized keys in `mcp.MiniMax`), verify:
+
+- OpenCode's MCP schema/version matches the config format you are using.
+- You translated fields according to OpenCode docs (this README primarily provides Claude/Cursor examples).
+- Model provider settings and MCP server settings are configured in their respective sections.
+
+For OpenCode-specific keys and structure, follow the latest OpenCode documentation first, then map MiniMax env vars (`MINIMAX_API_KEY`, `MINIMAX_API_HOST`) into that schema.
+
+### 5. Does MiniMax MCP support standard MCP OAuth discovery endpoints?
+This repository (`MiniMax-MCP`) is an MCP server implementation that is typically configured with API key environment variables.  
+OAuth discovery/login support for adding third-party MCP services depends on the MCP client product (for example, web apps/IDE integrations), not only on this server repository.
+
+If your client reports OAuth URL discovery errors when connecting to a custom MCP endpoint, verify client-side OAuth support and required discovery paths in that client's latest documentation.
+
 
 ## Example usage
 


### PR DESCRIPTION
## Summary
- add FAQ entries (EN/CN) clarifying OAuth discovery responsibility boundaries
- explain that custom MCP OAuth login/discovery behavior depends on the client product implementation, not only this server repo

## Why
Users are asking whether MiniMax MCP itself guarantees standard OAuth discovery support for all clients.

Refs #44
