### PR TITLE
fix: update default speech and music models

### DIFF
--- a/minimax_mcp/const.py
+++ b/minimax_mcp/const.py
@@ -1,7 +1,7 @@
 # speech model default values
 DEFAULT_VOICE_ID = "female-shaonv"
-DEFAULT_SPEECH_MODEL = "speech-2.6-hd"
-DEFAULT_MUSIC_MODEL = "music-2.0"
+DEFAULT_SPEECH_MODEL = "speech-2.8-hd"
+DEFAULT_MUSIC_MODEL = "music-2.6"
 DEFAULT_SPEED = 1.0
 DEFAULT_VOLUME = 1.0
 DEFAULT_PITCH = 0


### PR DESCRIPTION
Bump default models in `minimax_mcp/const.py`:
- speech-2.6-hd -> speech-2.8-hd
- music-2.0 -> music-2.6

The newer versions are accessible to Coding Plan subscribers

Closes #80