### PR TITLE
fix: handle empty text_to_audio errors consistently

### DIFF
--- a/minimax_mcp/server.py
+++ b/minimax_mcp/server.py
@@ -87,9 +87,6 @@ def text_to_audio(
     format: str = DEFAULT_FORMAT,
     language_boost: str = DEFAULT_LANGUAGE_BOOST,
 ):
-    if not text:
-        raise MinimaxRequestError("Text is required.")
-
     payload = {
         "model": model,
         "text": text,
@@ -111,6 +108,9 @@ def text_to_audio(
     if resource_mode == RESOURCE_MODE_URL:
         payload["output_format"] = "url"
     try:
+        if not text:
+            raise MinimaxRequestError("Text is required.")
+
         response_data = api_client.post("/v1/t2a_v2", json=payload)
         audio_data = response_data.get('data', {}).get('audio', '')
         

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,21 @@
+import importlib
+import sys
+
+from mcp.types import TextContent
+
+
+def load_server(monkeypatch):
+    monkeypatch.setenv("MINIMAX_API_KEY", "test-key")
+    monkeypatch.setenv("MINIMAX_API_HOST", "https://api.example.com")
+    sys.modules.pop("minimax_mcp.server", None)
+    return importlib.import_module("minimax_mcp.server")
+
+
+def test_text_to_audio_returns_text_content_for_empty_text(monkeypatch):
+    server = load_server(monkeypatch)
+
+    result = server.text_to_audio(text="")
+
+    assert isinstance(result, TextContent)
+    assert result.type == "text"
+    assert result.text == "Failed to generate audio: Text is required."


### PR DESCRIPTION
## Summary
- move the empty `text_to_audio` text validation inside the existing `try` block
- add a regression test that expects empty text to return a `TextContent` error instead of raising `MinimaxRequestError`

Fixes #88.

## Verification
- `.\.venv\Scripts\python.exe -m pytest -q` — 7 passed
- `.\.venv\Scripts\python.exe -m pytest --cov=minimax_mcp` — 7 passed
- `.\.venv\Scripts\ruff.exe check tests/test_server.py` — passed
- `git diff --check` — passed

## Notes
`ruff check .` still reports pre-existing lint issues in the repository, including the current HEAD version of `server.py`; this PR keeps the change scoped to the validation behavior and the regression test.